### PR TITLE
Removed /r's from script

### DIFF
--- a/elasticsearch.nse
+++ b/elasticsearch.nse
@@ -22,38 +22,38 @@ action = function(host, port)
   local response = http.get(host, port, uri)
   if ( response.status == 200 ) then
     if ( string.find(response.body, "You Know, for Search") ) then
-      local out = "by theMiddle (Twitter: @Menin_TheMiddle)\r\n\r\n"
-      out = out .. "found RESTful API\r\n"
+      local out = "by theMiddle (Twitter: @Menin_TheMiddle)\n\n"
+      out = out .. "found RESTful API\n"
       err, esjson = json.parse(response.body)
 
-      out = out .. "version: ".. esjson['version']['number'] .."\r\n"
+      out = out .. "version: ".. esjson['version']['number'] .."\n"
 
       if esjson['cluster_name'] then
-        out = out .. "cluster name: " .. esjson['cluster_name'] .. "\r\n"
+        out = out .. "cluster name: " .. esjson['cluster_name'] .. "\n"
       end
 
-      out = out .. "\r\nIndices found in /_cat/indices:\r\n"
+      out = out .. "\nIndices found in /_cat/indices:\n"
       local resindices = http.get_url("http://"..host.ip..":"..port.number.."/_cat/indices?pri&v&h=health,index,docs.count")
       out = out .. resindices.body
 
-      out = out .. "\r\nPlugins found in /_cat/plugins:\r\n"
+      out = out .. "\nPlugins found in /_cat/plugins:\n"
       local resplugins = http.get_url("http://"..host.ip..":"..port.number.."/_cat/plugins")
       out = out .. resplugins.body
 
-      out = out .. "\r\nNodes found in /_cat/nodes:\r\n"
+      out = out .. "\nNodes found in /_cat/nodes:\n"
       local resnodes = http.get_url("http://"..host.ip..":"..port.number.."/_cat/nodes")
       out = out .. resnodes.body
 
-      out = out .. "\r\nNodes process:\r\n"
+      out = out .. "\nNodes process:\n"
       local resprocess = http.get_url("http://"..host.ip..":"..port.number.."/_nodes/_all/process")
       err, psjson = json.parse(resprocess.body)
 
       for key,value in pairs(psjson['nodes']) do
-        out = out .. " - Name: " .. value['name'] .. "\r\n"
-        out = out .. " - Transport Address: " .. value['transport_address'] .. "\r\n"
-        out = out .. " - Host: " .. value['host'] .. "\r\n"
-        out = out .. " - IP: " .. value['ip'] .. "\r\n"
-        out = out .. " - Version: " .. value['version'] .. "\r\n\r\n"
+        out = out .. " - Name: " .. value['name'] .. "\n"
+        out = out .. " - Transport Address: " .. value['transport_address'] .. "\n"
+        out = out .. " - Host: " .. value['host'] .. "\n"
+        out = out .. " - IP: " .. value['ip'] .. "\n"
+        out = out .. " - Version: " .. value['version'] .. "\n\n"
       end
 
       return out


### PR DESCRIPTION
`/r` carriage returns were showing up as `\x0D` in the script output

![image](https://user-images.githubusercontent.com/27816854/85904688-ff254500-b7ce-11ea-99e7-334b80b12f65.png)

```none
# nmap -V

Nmap version 7.60 ( https://nmap.org )
Platform: x86_64-pc-linux-gnu
Compiled with: liblua-5.3.3 openssl-1.1.0g nmap-libssh2-1.8.0 libz-1.2.8 libpcre-8.39 libpcap-1.8.1 nmap-libdnet-1.12 ipv6
Compiled without:
Available nsock engines: epoll poll select
```